### PR TITLE
for discussion: series of changes to about, why-hpc, and workshop pages

### DIFF
--- a/about.md
+++ b/about.md
@@ -4,7 +4,51 @@ layout: base
 
 # About HPC Carpentry
 
-HPC Carpentry is not an organization - 
-it is merely a set of publicly available teaching materials designed to make the task of teaching HPC a little easier.
-We welcome all contributions, in particular adaptations of our Intro to HPC lesson for other schedulers besides SLURM.
+HPC Carpentry is a set of publicly available teaching materials designed to make the 
+task of teaching HPC a little easier.  These lessons are specifically aimed at academic
+researchers who are new to the task of using remote, large-scale computing (see [Why 
+HPC Carpentry](why-hpc-carpentry)).  
 
+The HPC Carpentry lessons have been developed for instructors 
+looking to teach introductory workshops on high-performance computing.
+Lessons follow the Carpentries format: 
+all teaching is done via live coding, 
+with students following along with the instructor on their own computer.
+No prior experience is required, 
+and the workshop itself requires only a two-day committment from instructors and attendees.  
+Students should be able to leave the workshop and immediately begin working on an HPC system.
+
+## Using the materials and name
+
+Anyone is welcome to use, remix and share the HPC Carpentry lesson materials for their 
+own purposes.  
+
+If you want to run a workshop under the "HPC Carpentry" name, 
+we ask that workshop organizers follow these guidelines: 
+
+* Use the [Carpentries][carpentries] teaching mode of live-coding instruction and hands-on learning
+* Run the workshop under the [Carpentries Code of Conduct][carpentries-coc]
+* Have at least one Carpentries-certified instructor
+* Teach at least the [hpc-intro][] lesson module, as well as any other [hpc-carpentry][] modules of your choice
+
+## Get in touch!  
+
+We would like to track workshops that use this material (whether officially branded as 
+HPC Carpentry or not).  Please fill out the following forms: 
+
+* [Before a workshop][pre-workshop]
+	* Let us know if you're interested in running a workshop (or planning to give one), 
+	and if you have any questions
+* [After a workshop][post-workshop]
+	* Provide feedback about what materials you used and how it went
+
+There is also an [HPC Carpentry mailing list hosted on Topicbox][hpc-list] -- sign up
+for ongoing announcements and conversation among the community.  
+
+[hpc-intro]: https://hpc-carpentry.github.io/hpc-intro/
+[hpc-carpentry]: https://hpc-carpentry.github.io/
+[carpentries]: https://carpentries.org/
+[carpentries-coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[pre-workshop]: google.link
+[post-workshp]: google.link
+[hpc-list]: https://carpentries.topicbox.com/groups/discuss-hpc

--- a/why-hpc-carpentry.md
+++ b/why-hpc-carpentry.md
@@ -5,31 +5,31 @@ layout: base
 # Why HPC Carpentry?
 
 HPC Carpentry's materials were developed to address 
-the relative lack of introductory materials for high-performance computing environments.
+the relative lack of introductory materials for high-performance computing environments, 
+including, but not limited to supercomputers, campus clusters, distributed high throughput 
+systems and cloud computing.  
 Most materials currently available either assume a certain level of prerequisite knowledge,
 or are in the wrong format for introductory workshops 
-(either lecture-based or had a very long teaching time).
-Until recently, the best option for teaching basic workshops on HPC 
-was to teach one of the popular Software Carpentry workshops, 
+(either lecture-based or have a very long teaching time).
+Until recently, the best option for teaching basic workshops on remote, large-scale  
+compute resources was to teach one of the popular [Software Carpentry][swc] workshops, 
 with a brief HPC component tacked on or crammed into various sections. 
 This was not a good solution in most cases - 
 Software Carpentry's materials are already more or less "full" 
 (something added comes at the expense of something else),
 and the languages/topics of the workshops 
 was not particularly well matched for problems commonly encountered in HPC
-(for instance, hardcore number crunching or execution of large numbers of externally written programs and tools).
+(for instance, hardcore number crunching or execution of large numbers of externally 
+written programs and tools).
 
-The HPC Carpentry lessons have been developed for instructors 
-looking to teach introductory workshops on high-performance computing.
-Lessons follow the Software Carpentry format: 
-all teaching is done via live coding, 
-with students following along with the instructor on their own computer.
-No prior experience is required, 
-and the workshop itself requires only a two-day committment from instructors and attendees.Students should be able to leave the workshop and immediately begin working on an HPC system.
+See [About HPC Carpentry](about) for information about HPC Carpentry in general
+and [Running a workshop](workshops) for details about how to run your own HPC 
+Carpentry workshop.  
 
 Instructors simply looking to teach basic programming skills in R or Python 
 are highly encouraged to check out the materials offered by 
-[Software Carpentry](https://software-carpentry.org/).
+[Software Carpentry][swc].
 Software Carpentry's lessons are more generally applicable 
 introductory programming materials that do not have an HPC component.
 
+[swc]: https://software-carpentry.org/

--- a/workshops.md
+++ b/workshops.md
@@ -2,10 +2,17 @@
 layout: base
 ---
 
-# Leading a workshop
+# Running a Workshop
 
-HPC Carpentry workshops are interactive affairs, 
-designed to help users get started using an HPC system.
+If you have an audience that would benefit from an HPC Carpentry workshop, this 
+page will provide guidance about running a workshop!  To help us help you, 
+please do the following before getting started: 
+
+* [review our guidelines for using the HPC Carpentry name](about)
+* [fill out the interest form][pre-workshop]
+
+## General setup
+
 As an instructor, you should ideally set up or arrange access to a computing cluster for your workshop.
 Each student will need their own account on the cluster.
 Our materials assume that you are using some form of environment modules to manage software installation, and use a batch scheduler to schedule jobs.
@@ -19,16 +26,25 @@ a projector, and enough power outlets or extension cords for students to bring t
 You can also quickly create a lesson website using the Software Carpentry 
 [workshop-template](https://github.com/swcarpentry/workshop-template)
 and arrange for attendee registration through Eventbrite.
-It is recommended (though not strictly required) that instructors be a Software Carpentry certified instructor and be familiar with that style of interactive teaching.
 
------------------------------------------------------------
+If you want to customize the materials, we recommend "forking" them to a Github account 
+associated with you.  The `fork` button at the top right 
+of each main repository page will prompt you to create a copy of the materials 
+in your own or an organizational account.  There 
+will be a corresponding website with these materials at the link:
+```
+https://<GithubAccount>.github.io/<LessonName>
+```
+Once this copy is created, you can edit 
+the lesson materials (contained in the `_episodes` folder) directly on Github or, if 
+you're familiar with remote git workflows, through a cloned copy of the fork.  
 
-# Lesson-specific setup
+## Lesson-specific setup
 
 In addition to the steps above, 
 there are several additional pieces of setup to be performed depending on which lessons are being taught.
 
-## Analysis Pipelines with Python
+### Analysis Pipelines with Python
 
 Although most work will be performed on student's laptops, 
 the final segment (scaling jobs across a cluster) will occur on your cluster environment.
@@ -37,7 +53,7 @@ You should have some version of Python 3 preinstalled for students to use.
 Don't preinstall Snakemake on the system for users (unless it's already there), 
 as this lets students practice installing local Python packages on their account.
 
-## Parallel Computing with Chapel
+### Parallel Computing with Chapel
 
 Chapel can be a tricky package to setup for newcomers and does not run on Windows (except through something like Docker or Cygwin).
 We recommend setting up an installation of Chapel on your cluster beforehand for use in the workshop.
@@ -48,3 +64,5 @@ It is also possible to use the Chapel [Docker image](https://hub.docker.com/r/ch
 If you choose to use the Chapel Docker image, 
 make sure students install [Docker](https://www.docker.com/) before the workshop.
 
+
+[pre-workshop]: google.link


### PR DESCRIPTION
* moved some information from `why-hpc` to `about`
* added contact information + forms (tbd) to `about`
* added instructions about using the HPC Carpentry name to `about`
* slight changes to `workshops`, mostly removing redundant info