### PR TITLE
Fix contact page and add Twitter feed there

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -3,19 +3,22 @@ layout: page-fullwidth
 title: "Contact Us"
 permalink: /contact/
 ---
-    
+<br>
 <div class="row">
-  <div class="medium-5 columns">
-    <strong>by email:</strong>
-    General enquiries: <br>
-    <a href="mailto:{{site.contact}}">{{site.contact}}</a><br>
-  </div> 
-  <div class="medium-3 columns">
-    <strong>on Twitter:</strong>
-    <br><br>
-    <a href="https://twitter.com/hpccarpentry?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">
+<div class="medium-4 columns">
+<strong>by email:</strong>
+<br>General enquiries: <br>
+<a href="mailto:{{site.contact}}">{{site.contact}}</a><br>
+</div> 
+<div class="medium-4 columns">
+<strong>on Twitter:</strong>
+<br><br>
+<a href="https://twitter.com/hpccarpentry?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">
       Follow @hpccarpentry
-    </a>
-    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  </div>
+</a>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</div>
+<div class="medium-4 columns">
+<a class="twitter-timeline" href="https://twitter.com/hpccarpentry?ref_src=twsrc%5Etfw">Tweets by hpccarpentry</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</div>
 </div>


### PR DESCRIPTION
Fixes #26 

Unfortuntely if we lint this as html, Jekyll seems to think that we want to show code and places all the html in code blocks rather than rendering them.

It was also very bare so I thought maybe the Twitter feed could give it some meat.