### PR TITLE
Steering committee info.

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -4,6 +4,22 @@ title: "Contact Us"
 permalink: /contact/
 ---
 <br>
+<head>
+Steering Committee
+</head>
+<p>
+HPC Carpentry is lead by a steering committee. The members help to foster the HPC Carpentry organization and its lessons, guide curriculum development following The Carpentries Handbook, and participate in discussions with The Carpentries in a representative capacity to help us navigate the pathway to induction as an official Lesson Program.
+</p>
+<p>
+The members (and their github handles) are:
+</p>
+<ul>
+<li>Andrew Reid @reid-a</li> 
+<li>Alan O'Cais @ocaisa</li> 
+<li>Annajiat Alim Rasel @annajiat</li> 
+<li>Trevor Keller @tkphd</li> 
+<li>Wirawan Purwanto @wirawan0</li>
+</ul>
 <div class="row">
 <div class="medium-4 columns">
 <strong>by email:</strong>

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -11,7 +11,7 @@ Steering Committee
 HPC Carpentry is lead by a steering committee. The members help to foster the HPC Carpentry organization and its lessons, guide curriculum development following The Carpentries Handbook, and participate in discussions with The Carpentries in a representative capacity to help us navigate the pathway to induction as an official Lesson Program.
 </p>
 <p>
-The members (and their github handles) are:
+The members (and their GitHub handles) are:
 </p>
 <ul>
 <li>Andrew Reid @reid-a</li> 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -32,7 +32,7 @@ widget3:
   title: "Who we are"
   url: 'https://hpc-carpentry.org/contact/'
   icon: 'fas fa-users'
-  text: >1
+  text: >
     Our diverse, global community includes scientists, engineers, system
     administrators, and <a href="/community/">computing enthusiasts of all
     stripes</a>.

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -30,9 +30,9 @@ widget2:
     edits. Welcome!
 widget3:
   title: "Who we are"
-  url: 'https://carpentries.org/about'
+  url: 'https://hpc-carpentry.org/contact/'
   icon: 'fas fa-users'
-  text: >
+  text: >1
     Our diverse, global community includes scientists, engineers, system
     administrators, and <a href="/community/">computing enthusiasts of all
     stripes</a>.


### PR DESCRIPTION
Steering committee names are on the "contact" page, and the
main-page link under "About us" has been re-pointed to our
contact page.

Closes #33.