### PR TITLE
Make event data resilient against 'Loading...'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,11 @@ lesson_data:
 ## event data  : pull our event data from our Google Form (which is saved in a spreadsheet)
 # - we need to pull a particular sheet from the google doc so that we retain our own headings
 #   (sheet contents mirror form responses, but only first 300 entries!)
+# - our event data needs to be "warmed up" as it is pulled from another sheet, check for this
+#   by looking for "Loading..." in the downloaded file (and retry if it exists)
 # - take our event data and turn it into json
 event_data:
-	curl -L -o _data/workshops.tsv "https://docs.google.com/spreadsheets/d/16xY1AziEqE11Aq26aMwlyoJgpkibWb0425KFqbchaiE/export?format=tsv&id=16xY1AziEqE11Aq26aMwlyoJgpkibWb0425KFqbchaiE&gid=1609449263"
+	bash feeds/get_workshops_data.sh _data/workshops.tsv
 	python feeds/workshops.py
 
 #-------------------------------------------------------------------------------

--- a/feeds/get_workshops_data.sh
+++ b/feeds/get_workshops_data.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+if [ $# -ne 1 ]
+  then
+    echo -e "Usage:\n\t<script> <output file>"
+    exit 1
+else
+  output_file=$1
+fi
+
+# Using "1" as value for false
+sleep_a_bit=1
+num_attempts=0
+file_received=1
+until [ "$file_received" = true ]
+do
+  if [ "$sleep_a_bit" = true ] ; then
+    sleep_time=30
+    echo "Sleeping $sleep_time seconds to give the file a chance to update"
+    sleep $sleep_time
+  fi
+  # Grab the file
+  echo "Attempting file download..."
+  curl -L -o "$output_file" 'https://docs.google.com/spreadsheets/d/16xY1AziEqE11Aq26aMwlyoJgpkibWb0425KFqbchaiE/export?format=tsv&id=16xY1AziEqE11Aq26aMwlyoJgpkibWb0425KFqbchaiE&gid=1609449263'
+
+  # Check for "Loading..." string as this means the file was still warming up
+  if grep -q "Loading..." "$output_file"; then
+    ((num_attempts=num_attempts+1))
+    if [ "$num_attempts" -eq "5" ]; then
+      echo "Downloaded file still contains 'Loading...' after $num_attempts) attempts...exiting!"
+      exit 1
+    fi
+    echo "Downloaded file contains 'Loading...' string: retrying (attempt $num_attempts)"
+    sleep_a_bit=true
+  else
+    file_received=true
+  fi
+done


### PR DESCRIPTION
Our event data on Google Sheets is referenced from another sheet and if it hasn't been viewed in a while it needs to be fetched. This manifests as "Loading..." appearing in the file fetched by curl rather than actual data. 