### PR TITLE
Add external lesson from JSC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ data : lesson_data event_data
 # (requires GitHub PAT provided via GITHUB_PAT env var)
 lesson_data:
 	R -q -e "source('feeds/hpc-carpentry_lessons.R')"
+	R -q -e "source('feeds/other_lessons.R')"
 ## help-wanted: list of issues that have the label "help wanted"
 	R -q -e "source('feeds/help_wanted_issues.R')"
 

--- a/feeds/help_wanted_issues.R
+++ b/feeds/help_wanted_issues.R
@@ -108,6 +108,7 @@ keep_other_repos <- function(orgs) {
   other_repos <- tibble::tribble(
     ~carpentries_org, ~repo,
     "carpentries-incubator", "hpc-intro",
+    "fzj-jsc", "tuning_lammps"
   )
 
   dplyr::inner_join(
@@ -119,7 +120,8 @@ keep_other_repos <- function(orgs) {
 
 list_organizations <- c(
   "HPC Carpentry" = "hpc-carpentry",
-  "The Carpentries Incubator" = "carpentries-incubator"
+  "The Carpentries Incubator" = "carpentries-incubator",
+  "Juelich Supercomputing Centre" = "fzj-jsc"
 )
 
 list_help_wanted <- purrr::imap_dfr(

--- a/feeds/other_lessons.R
+++ b/feeds/other_lessons.R
@@ -1,0 +1,74 @@
+source("feeds/utils.R")
+
+LIFE_CYCLE_TAGS <- c("pre-alpha", "alpha", "beta", "stable")
+# The tags below will be filtered out in the json
+COMMON_TAGS <- c(
+  "carpentries",
+  "carpentries-incubator",
+  "carpentries-lesson",
+  "carpentryconnect",
+  "data-carpentry",
+  "hpc-carpentry",
+  "datacarpentry",
+  "education",
+  "lesson"
+)
+
+check_missing_repo_info <- function(.d, field) {
+  if (any(!nzchar(.d[[field]]))) {
+    paste0(
+      "Missing repo ", sQuote(field), " for: \n",
+      paste0("  - ", .d$repo_url[!nzchar(.d[[field]])], collapse = "\n"),
+      "\n"
+    )
+  }
+}
+
+check_repo_info <- function(.d, fields) {
+  tryCatch({
+    out <- purrr::map(
+      fields, ~ check_missing_repo_info(.d, .)
+    )
+    msgs <- purrr::keep(out, ~ !is.null(.))
+
+    if (length(msgs)) {
+      stop(msgs, call. = FALSE)
+    }
+
+    cli::cli_alert_success("No issues detected!")
+  },
+  error = function(err) {
+    stop(err$message, call. = FALSE)
+  })
+}
+
+make_community_lessons_feed <- function(path, ...) {
+  jsc <- get_org_topics("FZJ-JSC")
+  res <- dplyr::bind_rows(jsc) %>%
+    dplyr::select(-private) %>%
+    dplyr::filter(grepl("hpc-carpentry", github_topics)) %>%
+    dplyr::filter(grepl("lesson", github_topics)) %>%
+    extract_tag(
+      life_cycle_tag,
+      LIFE_CYCLE_TAGS,
+      approach = "include",
+      allow_multiple = FALSE,
+      allow_empty = FALSE
+    ) %>%
+    extract_tag(
+      lesson_tags,
+      COMMON_TAGS,
+      approach = "exclude",
+      allow_multiple = TRUE,
+      allow_empty = TRUE
+    )
+
+  ## checks
+  check_repo_info(res, c("description", "rendered_site"))
+
+  res %>%
+    jsonlite::write_json(path = path)
+
+}
+
+make_community_lessons_feed("_data/other_lessons.json")

--- a/feeds/utils.R
+++ b/feeds/utils.R
@@ -96,7 +96,8 @@ get_github_topics <- function(owner, repo) {
 }
 
 get_org_topics <- function(org) {
-
+  # Organisation should be lower case
+  org <- tolower(org)
   get_list_repos(org) %>%
     dplyr::filter(
       !private,

--- a/pages/community-lessons.md
+++ b/pages/community-lessons.md
@@ -104,14 +104,12 @@ from The Carpentries.
 
 If you are interested in having a lesson included in our listings, please
 [open an issue in the repository of this website](https://github.com/hpc-carpentry/hpc-carpentry.github.io/issues).
--->
 
-<!--
 ### _Lessons in the HPC Listings_:
 
-{% assign lesson_list = site.data.hpc_lessons | where: "hpc_carpentry_org","FZJ-JSC" %}
+{% assign lesson_list = site.data.other_lessons %}
 {% include lesson_table %}
--->
+
 
 <hr>
 

--- a/pages/help-wanted-issues.md
+++ b/pages/help-wanted-issues.md
@@ -22,14 +22,13 @@ permalink: "/help-wanted-issues/"
 
 {% assign help_wanted = site.data.help_wanted_issues %}
 
-{% comment %}
-This was a way to get all the organizations automatically, but probably better to curate ordering
-
 {% assign orgs = help_wanted | map: "org_name" | uniq %}
-{% endcomment %}
+
+{% comment %}
+Currently we get all the organizations automatically, but probably better to curate ordering
 
 {% assign orgs = "The Carpentries Incubator, HPC Carpentry" | split: ", " %}
-
+{% endcomment %}
 
 {% for each_org in orgs %}
 


### PR DESCRIPTION
This includes an example of what modification is needed to add lessons from another organisation, and to add "help wanted" issues from a particular repository to our list.

Currently the way community lessons are pulled in is somewhat aggressive, in that it will list every lesson in the organisation that has a `lesson` and `hpc-carpentry` topic. Since we have no control over, this it leaves the lessons included a bit random.