### PR TITLE
Use specific version of EESSI in CI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Setup EESSI to give us R and Python modules
         uses: eessi/github-action-eessi@v1
+        eessi_stack_version: 2021.06
 
       - name: Create repository data files
         shell: bash

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Setup EESSI to give us R and Python modules
         uses: eessi/github-action-eessi@v1
-        eessi_stack_version: 2021.06
+        with:
+          eessi_stack_version: '2021.06'
 
       - name: Create repository data files
         shell: bash


### PR DESCRIPTION
Fixes #55 

Ran into a conflict because there are two (incompatible) versions of `SciPy-bundle` in the latest EESSI stack. If we stick with the older version of the EESSI pilot we avoid this issue.