### PR TITLE
Fixed to the e-mail addresses.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,7 @@ members.
    `2017-07-10-assess_report.md`
 
 4. In order to render correctly, posts need to have a header block,
-   which should be [created like this  example][hdr-block],
-   e.g.
+   which should be [created like this example][hdr-block]:
 
    ```yaml
    ---
@@ -84,9 +83,12 @@ members.
    ```
 
    Separate the header block from the post proper by a new line.
+   You can leave the `time` field as-is or set it to a meaningful
+   value. Please make your best effort to accurately populate the
+   rest of the fields.
 
-5. `Time`, but the other fields should be filled in. If there is more
-   than one author, separate the author names like this:
+5. If there is more than one author, separate the quoted author
+   names using commas, like this:
 
    ```yaml
    ["Name 1", "Name 2"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,133 +1,151 @@
 # Contributing
 
-Like the official [Carpentries][c-site] sites [Software Carpentry][swc-site], [Data Carpentry][dc-site],
-and [Library Carpentry][lc-site]; [HPC Carpentry][hpcc-site] is an open source project,
-and we welcome contributions of all kinds:
-blog posts,
-fixes to existing material,
-bug reports,
-and reviews of proposed changes are all welcome.
+Like the official [Carpentries][c-site] sites---[Software
+Carpentry][swc-site], [Data Carpentry][dc-site], and
+[Library Carpentry][lc-site]---[HPC Carpentry][hpcc-site]
+is an open source project, and we welcome
+contributions of all kinds: blog posts, fixes to existing material,
+bug reports, and reviews of proposed changes are all welcome.
 
 ## Contributor Agreement
 
-By contributing,
-you agree that we may redistribute your work under [our license](LICENSE.md).
-Everyone involved in i[HPC Carpentry][hpcc-site] 
-agrees to abide by our [code of conduct][conduct].
-
+By contributing, you agree that we may redistribute your work under
+[our license](LICENSE). Everyone involved in
+[HPC Carpentry][hpcc-site] agrees to abide by our
+[code of conduct][conduct].
 
 ## How to Contribute a Fix or Suggested Change
 
-The easiest way to get started is to file an issue
-to tell us about a spelling mistake,
-some awkward wording,
-or a factual error.
-This is a good way to introduce yourself
-and to meet some of our community members.
+The easiest way to get started is to file an issue to tell us about a
+spelling mistake, some awkward wording, or a factual error. This is
+a good way to introduce yourself and to meet some of our community
+members.
 
-1.  If you do not have a [GitHub][github] account,
-    you can send comments to the [community email list][discuss-list].
-    However,
-    we will be able to respond more quickly if you use one of the other methods described below.
+1. If you do not have a [GitHub][github] account, you can send
+   comments to the [community email list][discuss-list].
+   However, we will be able to respond more quickly if you use one of
+   the other methods described below.
 
-2.  If you have a [GitHub][github] account,
-    or are willing to [create one][github-join],
-    but do not know how to use Git,
-    you can report problems or suggest improvements by [creating an issue][issues].
-    This allows us to assign the item to someone
-    and to respond to it in a threaded discussion.
+2. If you have a [GitHub][github] account, or are willing to
+   [create one][github-join], but do not know how to use Git,
+   you can report problems or suggest improvements by
+   [creating an issue][issues].
+   This allows us to assign the item to someone and to respond
+   to it in a threaded discussion.
 
-3.  If you are comfortable with Git,
-    and would like to add or change material,
-    you can submit a pull request (PR).
+3. If you are comfortable with Git, and would like to add or change
+   material, you can submit a pull request (PR).
 
 ## Where to Contribute
 
-1.  If you wish to change the website,
-    please work in <https://github.com/hpc-carpentry/hpc-carpentry.github.io>,
-    which can be viewed at <https://hpc-carpentry.org>.
+1. If you wish to change the website, please work in
+   <https://github.com/hpc-carpentry/hpc-carpentry.github.io>,
+   which can be viewed at <https://hpc-carpentry.org>.
 
-2.  If you wish to change CSS style files, tools,
-    or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/carpentries/carpentries.org> (on which
-    this website is based).
+2. If you wish to change CSS style files, tools, or HTML boilerplate
+   for lessons or workshops stored in `_includes` or `_layouts`,
+   please work in <https://github.com/carpentries/carpentries.org>
+   (on which this website is based).
 
 ## How to Contribute a Blog Post
 
-1.  If you wish to contribute a blog post,
-    please work in <https://github.com/hpc-carpentry/hpc-carpentry.github.io>,
-    which can be viewed at <https://hpc-carpentry.org>.
-    
-2.  Posts go in the `_posts` folder, which is divided up first by year,
-    e.g. `2018`, and then by month, e.g. `04`. Be sure to start creating your file in
-    the correct folder. 
-    
-3.  Posts need to be created in [Markdown](https://guides.github.com/features/mastering-markdown/) and named 
-    according to this convention (all-lower-case filenames are preferred):
-    
-    `YYYY-MM-DD-filename.md`
-    
-    e.g. 
-    
-    `2017-07-10-assess_report.md`
-    
-4.  In order to render correctly, posts need to have a [header block, which should be created like this example](https://raw.githubusercontent.com/carpentries/carpentries.org/main/_posts/2018/04/2018-04-11-launch-handbook.md), e.g.
+1. If you wish to contribute a blog post, please work in
+   <https://github.com/hpc-carpentry/hpc-carpentry.github.io>,
+   which can be viewed at <https://hpc-carpentry.org>.
+  
+2. Posts go in the `_posts` folder, which is divided up first by
+   year, e.g. `2018`, and then by month, e.g. `04`. Be sure to start
+   creating your file in the correct folder.
 
-```
----
-layout: page
-authors: ["Tracy Teal", "Maneesha Sane", "Belinda Weaver"]
-title: "Launching our New Handbook"
-teaser: "Find new pathways to a range of Carpentries material"
-date: 2018-04-11
-time: "9:00:00"
-tags: ["Communications"]
----
-```
+3. Posts need to be created in [Markdown][md-guide] and named
+   according to this convention (all-lower-case filenames are
+   preferred):
 
-Separate the header block from the post proper by a new line. 
-    
-5.  `Time`, but the other fields should be filled in. If there is more than one author,
-    separate the author names like this: `["Name 1", "Name 2"]`. Separate any tags the same way.
-    
-6.  Images should be uploaded to the appropriate year in the `files/<year>/<month>` folder. Images should be linked using 
-    Markdown, and paths to the image should be relative. 
-    Example: 
-    ```
-    ![Image Description]({{ site.filesurl }}/2017/07/myimage.jpg)
-    ```
-    A web link should be used for images hosted elsewhere. 
-    Example: 
-    ``` 
-    ![Image Description](https://web_address/pathway_to_full_image_filename)
-    ```
-    
-    If you are not sure how to add images in Markdown format, look at an [existing Software Carpentry post with a locally hosted image](https://raw.githubusercontent.com/swcarpentry/website/main/_posts/2017/06/2017-06-19-mqu-ttt.md) or [one with a web link](https://raw.githubusercontent.com/swcarpentry/website/main/_posts/2017/07/2017-07-10-assess_report.md) and copy the formatting from there.
-    
-7.  Once you have previewed your file, commit the Markdown file to your fork and start a Pull Request. We automatically run tests using [GitHub Actions](https://github.com/features/actions) on your Pull Requests. Please review your pull request a few minutes after you've submitted it to make sure those tests have passed. These tests look for valid YAML headers and make sure that the post will build properly.
+   `YYYY-MM-DD-filename.md`
+
+   e.g.,
+
+   `2017-07-10-assess_report.md`
+
+4. In order to render correctly, posts need to have a header block,
+   which should be [created like this  example][hdr-block],
+   e.g.
+
+   ```yaml
+   ---
+   layout: page
+   authors: ["Tracy Teal", "Maneesha Sane", "Belinda Weaver"]
+   title: "Launching our New Handbook"
+   teaser: "Find new pathways to a range of Carpentries material"
+   date: 2018-04-11
+   time: "9:00:00"
+   tags: ["Communications"]
+   ---
+   ```
+
+   Separate the header block from the post proper by a new line.
+
+5. `Time`, but the other fields should be filled in. If there is more
+   than one author, separate the author names like this:
+
+   ```yaml
+   ["Name 1", "Name 2"]
+   ```
+
+   Separate any tags the same way.
+
+6. Images should be uploaded to the appropriate year in the
+   `files/<year>/<month>` folder. Images should be linked using
+   Markdown, and paths to the image should be relative. Example:
+
+   ```markdown
+   ![Image Description]({{ site.filesurl }}/2017/07/myimage.jpg "alt text")
+   ```
+
+   A web link should be used for images hosted elsewhere.
+   Example:
+
+   ```markdown
+   ![Image Description](https://web_address/pathway_to_full_image_filename)
+   ```
+
+   If you are not sure how to add images in Markdown format,
+   look at an existing Carpentries post with a
+   [locally hosted image][md-img-local] or
+   [one with a web link][md-img-remote] and copy the formatting
+   from there.
+
+7. Once you have previewed your file, commit the Markdown file to
+   your fork and start a Pull Request. We automatically run tests
+   using [GitHub Actions][actions] on your Pull Requests. Please
+   review your pull request a few minutes after you've submitted it
+   to make sure those tests have passed. These tests look for valid
+   YAML headers and make sure that the post will build properly.
   
 ## Other Resources
 
-General discussion of [HPC Carpentry][hpcc-site]
-happens on the [discussion mailing list][discuss-list],
-which everyone is welcome to join.
-You can also [reach the maintainers by email][contact].
+General discussion of [HPC Carpentry][hpcc-site] happens on the
+[discussion mailing list][discuss-list], which everyone is welcome
+to join. You can also [reach the maintainers by email][contact].
 
-[contact]: mailto:maintainers-hpc@lists.carpentries.org
+<!-- HPCC links -->
+
+[actions]: https://github.com/hpc-carpentry/hpc-carpentry.github.io/actions
 [conduct]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
-[dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
-[dc-lessons]: https://datacarpentry.org/lessons/
-[dc-site]: https://datacarpentry.org/
+[contact]: mailto:maintainers-hpc@lists.carpentries.org
 [discuss-list]: https://carpentries.topicbox.com/groups/discuss-hpc
-[github]: http://github.com
-[github-flow]: https://guides.github.com/introduction/flow/
-[github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/hpc-carpentry/hpc-carpentry.github.io/issues/
-[repo]: https://github.com/hpc-carpentry/hpc-carpentry.github.io
-[swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
-[swc-lessons]: http://software-carpentry.org/lessons/
-[swc-site]: http://software-carpentry.org/
-[lc-issues]: https://github.com/issues?q=user%3Adatacarpentry
-[lc-lessons]: https://librarycarpentry.org/lessons/
+[hpcc-site]: https://www.hpc-carpentry.org
+
+<!-- Outside links -->
+
+[c-site]: https://carpentries.org
+[dc-site]: https://datacarpentry.org/
+[github-join]: https://github.com/join
+[github]: http://github.com
+[hdr-block]: https://github.com/hpc-carpentry/hpc-carpentry.github.io/blob/967908bd97f2e30f34185ad98d575a9125754b01/_posts/2024/08/2024-08-13-llnl-workshop-blog-post.md?plain=1#L1
 [lc-site]: https://librarycarpentry.org/
+[md-guide]: https://guides.github.com/features/mastering-markdown/
+[md-img-local]: https://github.com/carpentries/carpentries.org/blob/5524366743246303aa1dd80343dd4759685b44e9/_posts/2017/06/2017-06-19-mqu-ttt.md?plain=1#L29
+[md-img-remote]: https://github.com/carpentries/carpentries.org/blob/5524366743246303aa1dd80343dd4759685b44e9/_posts/2017/07/2017-07-10-assess_report.md?plain=1#L24
+[swc-site]: http://software-carpentry.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ This is a good way to introduce yourself
 and to meet some of our community members.
 
 1.  If you do not have a [GitHub][github] account,
-    you can [send us comments by email][contact].
+    you can send comments to the [community email list][discuss-list].
     However,
     we will be able to respond more quickly if you use one of the other methods described below.
 
@@ -111,7 +111,7 @@ Separate the header block from the post proper by a new line.
 General discussion of [HPC Carpentry][hpcc-site]
 happens on the [discussion mailing list][discuss-list],
 which everyone is welcome to join.
-You can also [reach us by email][contact].
+You can also [reach the maintainers by email][contact].
 
 [contact]: mailto:maintainers-hpc@lists.carpentries.org
 [conduct]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html

--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,8 @@ github_url     : "https://github.com/hpc-carpentry"
 github_io_url  : "http://hpc-carpentry.github.io"
 incubator_url  : "https://github.com/carpentries-incubator"
 incubator_io   : "https://carpentries-incubator.github.io"
-contact        : "maintainers-hpc@lists.carpentries.org"
+contact_org    : "maintainers-hpc@lists.carpentries.org" # Closed list
+contact_com    : "discuss-hpc@lists.carpentries.org"  # Community
 contact_dach   : ""
 contact_nz     : "admin-nz@carpentries.org"  # Megan Guidry, New Zealand
 contact_uk     : ""

--- a/_includes/mailchimp_signup_form.html
+++ b/_includes/mailchimp_signup_form.html
@@ -56,7 +56,7 @@
         <fieldset class="mc_fieldset gdprRequired mc-field-group" name="interestgroup_field">
 		<label class="checkbox subfield" for="gdpr_963"><input type="checkbox" id="gdpr_963" name="gdpr[963]" value="Y" class="av-checkbox "><span>Email</span> </label>
         </fieldset>
-        <p>You can change your mind at any time by clicking the unsubscribe link in the footer of any email you receive from us, or by contacting us at <a href="mailto:{{site.contact}}">{{site.contact}}</a>.
+        <p>You can change your mind at any time by clicking the unsubscribe link in the footer of any email you receive from us, or by contacting us at <a href="mailto:{{site.contact_org}}">{{site.contact_org}}</a>.
 
 Privacy policy: <a href="https://docs.carpentries.org/topic_folders/policies/privacy.html" target="_blank">Our Privacy Policy</a>
 

--- a/pages/citations.md
+++ b/pages/citations.md
@@ -26,4 +26,5 @@ reports about our impact can be found in our
 -->
 
 Do you know about other works that should be listed here? If so, please
-[email us](mailto:{{ site.contact }}) to let us know. Thanks!
+[email the maintainers](mailto:{{ site.contact_org }}) to let them know. 
+Thanks!

--- a/pages/community-lessons.md
+++ b/pages/community-lessons.md
@@ -60,7 +60,7 @@ needs and to use these materials freely (all lessons should be licensed
 [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)).
 
 If you are interested in developing or submitting a lesson to the Carpentries
-Incubator, [contact us](mailto:{{ site.contact }}).
+Incubator, [contact the maintainers](mailto:{{ site.contact_org }}).
 Please read the information in The Carpentries' [Development of Lessons page](
 https://carpentries.org/involved-lessons/) if you would like to contribute to
 the development of a lesson already present in The Carpentries Incubator.

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -28,9 +28,11 @@ The members (with their GitHub handles and/or emails) are:
 <div class="row">
 <div class="medium-4 columns">
 <strong>by email:</strong>
-<br>General enquiries: <br>
-<a href="mailto:{{site.contact}}">{{site.contact}}</a><br>
+<br>Maintainer enquiries: <br>
+<a href="mailto:{{site.contact_org}}">{{site.contact_org}}</a><br>
 </div> 
+<br>Ask the broader HPC Carpentry community: <br>
+<a href="mailto:{{site.contact_com}}">{{site.contact_com}}</a><br>
 <div class="medium-4 columns">
 <strong>on Twitter:</strong>
 <br><br>

--- a/pages/help-wanted-issues.md
+++ b/pages/help-wanted-issues.md
@@ -85,7 +85,7 @@ The Carpentries Incubator
 or a repository listed in the [HPC Carpentry Listings]()
 and would like to add your repository to,
 or remove your repository from, this listing
-please <a href="mailto:{{site.contact}}">contact us</a>.
+please <a href="mailto:{{site.contact_org}}">contact the maintainers</a>.
 
 [Read this guide to learn more about how and when to add "help wanted" and other labels to
 issues on your lesson repository][handbook-github-labels].

--- a/pages/jobs.md
+++ b/pages/jobs.md
@@ -6,5 +6,5 @@ permalink: /jobs/
 
 Do you know of a job opening, vacancy, fundinging opportunity, or grants
 related to high performance computing, scientific computing, or the work we are
-doing? If so, please [email us](mailto:{{ site.contact }}) to let us know.
+doing? If so, please [email us](mailto:{{ site.contact_org }}) to let us know.
 Thanks!

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -8,7 +8,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 ---
 
 <p>
-  Please <a href="mailto:{{site.contact}}">contact us</a> with any general questions.
+  Please <a href="mailto:{{site.contact_org}}">contact the maintainers</a> with any general questions.
 </p>
 
 <div class="row">

--- a/pages/regional_NZ.html
+++ b/pages/regional_NZ.html
@@ -43,7 +43,7 @@ out <a href="https://amy.carpentries.org/forms/workshop/">this form</a> and
 Megan will get right back to you!
 <br><br>
 General questions about HPC Carpentry outside of New Zealand?
-Contact <a href="mailto:{{site.contact}}">{{ site.contact }}</a> and we’ll get
+Contact <a href="mailto:{{site.contact_org}}">{{ site.contact_org }}</a> and we’ll get
 your message to the right team member to follow up.
 <br><br>
 

--- a/pages/testimonials.md
+++ b/pages/testimonials.md
@@ -11,4 +11,4 @@ excerpt: testimonials about The Carpentries from our community
 -->
 <hr>
 
-<p>Have a story of your own you'd like to share? Please <a href="mailto:{{site.contact}}?subject=testimonial">let us know</a>.</p>
+<p>Have a story of your own you'd like to share? Please <a href="mailto:{{site.contact_org}}?subject=testimonial">let the maintainers know</a>.</p>


### PR DESCRIPTION
I have instituted a scheme where the "discuss-hpc" mailing list is for the broad community, and the "maintainers-hpc" is explcitly called out as being for organizers or maintainers, depending on which I felt flowed best with the adjacen text.