### PR TITLE
Improve flow of sentence about entry barriers

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -14,7 +14,7 @@ Carpentries, which is clearly reflected in things like our [Code of Conduct](/co
 **Vision:** Our vision is to be the leading inclusive community 
 teaching data and coding skills for HPC resources.
 
-**Mission:** Lower the barrier to entry to HPC operations for a wide 
+**Mission:** Lower the entry barrier to HPC operations for a wide 
 range of users, so that more people can benefit from the increasing 
 availability of increasingly sophisticated computer systems.
 

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -4,7 +4,7 @@ permalink: /lessons/
 title: Our Lessons
 redirect_from:
   - /lessons.html
-excerpt: All our lessons are created collaboratively and can be freely re-used, provided you cite us as the original source
+excerpt: All our lessons are created collaboratively and can be freely reused, provided you cite us as the original source
 ---
 
 <p>


### PR DESCRIPTION
To avoid the "double to" in the sentence 

> ... barrier to entry to HPC resources ...

I would propose to speak of *entry barriers* to ease the flow of the sentence.